### PR TITLE
Remove Emoji fonts from exported font-family in SVG

### DIFF
--- a/gui/UI/public/js/export.js
+++ b/gui/UI/public/js/export.js
@@ -4,28 +4,38 @@ function export_as_csv(csv,filename) {
   saveAs(csvData, filename+'.csv');
 }
 
+function save_as_svg_with_style(id, css, filename, resetWidth, remove) {
+  fetch(css)
+    .then(response => response.text())
+    .then(text => {
+      var svg_data = document.getElementById(id).innerHTML;
+      var head = '<svg id="' + id + 'Export" title="graph" version="1.1" xmlns="http://www.w3.org/2000/svg">';
 
-function save_as_svg_with_style(id,css,filename,resetWidth,remove){
-fetch(css)
-.then(response => response.text())
-.then(text => {
-    var svgElement = document.getElementById(id);
-    var svg_data = document.getElementById(id).innerHTML;
-    var head = '<svg id="'+ id +'Export" title="graph" version="1.1" xmlns="http://www.w3.org/2000/svg">';
-    var style = "<style>" + text + "</style>";
-    var full_svg = head +  style + svg_data + "</svg>";
+      //Remove any fonts containing "Emoji" from CSS style.
+      var modifiedText = text.replace(/(font-family:\s*("[^"]+"|'[^']+'|[^,]+),[^}]+)}/g, function (match, fontDeclaration) {
+        var modifiedFontDeclaration = fontDeclaration.replace(/("[^"]+"|'[^']+'|[^,]+)(\s*,\s*("[^"]+"|'[^']+'|[^,]+))/g, function (match, font1, font2) {
+          var fonts = [font1, font2].filter(function (font) {
+            return !/Emoji/.test(font);
+          });
+          return fonts.join(',').replace(',,', ',')
+        });
+        return modifiedFontDeclaration + '}';
+      });
 
-    var blob = new Blob([full_svg], {type: "image/svg+xml"});
-    saveAs(blob, filename+".svg");
+      var style = "<style>" + modifiedText + "</style>";
+      var full_svg = head + style + svg_data + "</svg>";
 
-    if (typeof remove !== 'undefined') {
-      $("#"+remove).remove();
-    }
-    if(resetWidth == true) {
-      $("#"+id).attr('width','100%');
-    }
-})
-};
+      var blob = new Blob([full_svg], {type: "image/svg+xml"});
+      saveAs(blob, filename+".svg");
+
+      if (typeof remove !== 'undefined') {
+        $("#"+remove).remove();
+      }
+      if (resetWidth == true) {
+        $("#"+id).attr('width', '100%');
+      }
+    });
+}
 
 function save_as_raster_with_style(id,css,filename,scale,type,resetWidth,remove){
 fetch(css)


### PR DESCRIPTION
Currently the SVG Export includes all Emoji Fonts in the font-family of the CSS Style. However, until now emoji fonts have not been implemented in Inkscape and others, and there's no timeframe for when this will be fixed. Within Inkscape this causes an issue where numbers are not rendered correctly. 

This is a simple fix, that removes Emoji Fonts from exported SVGs, while keeping the rest of the font-family as is.

Reference (aside from personal experience):
https://www.reddit.com/r/Inkscape/comments/vc74qa/emoji_fonts_in_inkscape/
https://gitlab.com/inkscape/inbox/-/issues/3149